### PR TITLE
Only apply the description field to know page types

### DIFF
--- a/_config/config.yml
+++ b/_config/config.yml
@@ -2,6 +2,9 @@
 Name: cwp-recipes-guidance
 After: 'framework/*','cms/*'
 ---
-BasePage:
+GuidancePage:
+  extensions:
+    - DescriptionExtension
+HubPage:
   extensions:
     - DescriptionExtension


### PR DESCRIPTION
Applying at BasePage means that all page types will attempt to add a Description field when they may not need it. There is also a known conflict with the BlogPost page type where Description shows in the CMS UI strangely.