### PR TITLE
Add consistent tag selection UI and fallback description

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ It includes related module dependencies, useful page types, guidance related fea
 See [License](LICENSE.md).
  
 ## Maintainers
-  - Add yourself here
-  - Cam Findlay <cam@camfindlay.com>
+  - Amanda Baker <amanda.baker@dia.govt.nz>
+  - Cam Findlay <cam.findlay@dia.govt.nz>
   
 ## Bugtracker
 Bugs are tracked in the issues section of this repository. Before submitting an issue please read over 

--- a/code/HubPage.php
+++ b/code/HubPage.php
@@ -33,6 +33,32 @@ class HubPage extends Page
     {
         $fields = parent::getCMSFields();
         $fields->removeByName('Content');
+
+        // Display the Taxonomy and Type as a single selectable item
+        //TODO more elegant way would be to get a PR in taxonomy module to provide a concatenated name and then use this in the gridfield.
+        $components = GridFieldConfig_RelationEditor::create();
+        $components->removeComponentsByType('GridFieldAddNewButton');
+        $components->removeComponentsByType('GridFieldEditButton');
+
+        $autoCompleter = $components->getComponentByType('GridFieldAddExistingAutocompleter');
+        $autoCompleter->setResultsFormat('$Name ($TaxonomyType)');
+
+        $dataColumns = $components->getComponentByType('GridFieldDataColumns');
+        $dataColumns->setDisplayFields(array(
+            'Name' => 'Term',
+            'TaxonomyType' => 'Type'
+        ));
+
+        $fields->addFieldToTab(
+            'Root.Tags',
+            GridField::create(
+                'Terms',
+                'Terms',
+                $this->Terms(),
+                $components
+            )
+        );
+
         return  $fields;
     }
 

--- a/templates/Layout/GuidancePage.ss
+++ b/templates/Layout/GuidancePage.ss
@@ -5,7 +5,7 @@
 <%-- main  --%>
 <div>
 
-	<p>$Description</p>
+	<p><% if $Description %>$Description<% else %>$MetaDescription<% end_if %></p>
 	<p>$LearningOutcomes</p>
 	<p>$Content</p>
 

--- a/templates/Layout/HubPage.ss
+++ b/templates/Layout/HubPage.ss
@@ -12,7 +12,11 @@
                     <a href="$Link">
                         <h2>$Title</h2>
                     </a>
-                    $Description
+                    <% if $Description %>
+                        $Description
+                    <% else %>
+                        $MetaDescription
+                    <% end_if %>
                     <% loop $Terms %>
                         $Name
                     <% end_loop %>


### PR DESCRIPTION
Add SilverStripe CMS pages have a MetaDescription (we could have actually used this for the description TBH, might be worth a discussion at a later point). For now this set it up so that if a page makes use of the meta description and doesn't have a description (like Page) now that the DescriptionExtension only applies to GuidancePage and HubPage.

Have also updated the tag selection customisation on HubPage to be the same UX. Still this should be handle in the taxonomy module long term.

Added maintainer details in Readme.